### PR TITLE
Use semanticdb-kotlin instead of com.sourcegraph.lsif-kotling as plugin ID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
-on: [push]
+on:
+  push:
+  pull_request:
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/semanticdb-kotlinc/build.gradle.kts
+++ b/semanticdb-kotlinc/build.gradle.kts
@@ -77,7 +77,7 @@ tasks.jar {
     manifest {
         attributes["Specification-Title"] = project.name
         attributes["Specification-Version"] = project.version
-        attributes["Implementation-Title"] = "com.sourcegraph.lsif-kotlin"
+        attributes["Implementation-Title"] = "semanticdb-kotlinc"
         attributes["Implementation-Version"] = project.version
     }
 }
@@ -210,9 +210,9 @@ subprojects {
                 freeCompilerArgs = freeCompilerArgs + listOf(
                     "-Xplugin=$pluginJar",
                     "-P",
-                    "plugin:com.sourcegraph.lsif-kotlin:sourceroot=${sourceroot}",
+                    "plugin:semanticdb-kotlinc:sourceroot=${sourceroot}",
                     "-P",
-                    "plugin:com.sourcegraph.lsif-kotlin:targetroot=${targetroot}"
+                    "plugin:semanticdb-kotlinc:targetroot=${targetroot}"
                 )
             }
         }

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerCommandLineProcessor.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerCommandLineProcessor.kt
@@ -15,7 +15,7 @@ const val VAL_TARGET = "targetroot"
 val KEY_TARGET = CompilerConfigurationKey<Path>(VAL_TARGET)
 
 class AnalyzerCommandLineProcessor: CommandLineProcessor {
-    override val pluginId: String = "com.sourcegraph.lsif-kotlin"
+    override val pluginId: String = "semanticdb-kotlinc"
     override val pluginOptions: Collection<AbstractCliOption> = listOf(
         CliOption(
             VAL_SOURCES ,

--- a/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
+++ b/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
@@ -36,8 +36,8 @@ class AnalyzerTest {
             compilerPlugins = listOf(AnalyzerRegistrar { document = it })
             verbose = false
             pluginOptions = listOf(
-                PluginOption("com.sourcegraph.lsif-kotlin", "sourceroot", path.toString()),
-                PluginOption("com.sourcegraph.lsif-kotlin", "targetroot", buildPath.toString())
+                PluginOption("semanticdb-kotlinc", "sourceroot", path.toString()),
+                PluginOption("semanticdb-kotlinc", "targetroot", buildPath.toString())
             )
             commandLineProcessors = listOf(AnalyzerCommandLineProcessor())
             workingDir = path.toFile()
@@ -488,8 +488,8 @@ class AnalyzerTest {
             compilerPlugins = listOf(AnalyzerRegistrar())
             verbose = false
             pluginOptions = listOf(
-                PluginOption("com.sourcegraph.lsif-kotlin", "sourceroot", path.toString()),
-                PluginOption("com.sourcegraph.lsif-kotlin", "targetroot", buildPath.toString())
+                PluginOption("semanticdb-kotlinc", "sourceroot", path.toString()),
+                PluginOption("semanticdb-kotlinc", "targetroot", buildPath.toString())
             )
             commandLineProcessors = listOf(AnalyzerCommandLineProcessor())
             workingDir = path.toFile()


### PR DESCRIPTION
For consistency with semanticdb-javac and semanticdb-scalac.