### PR TITLE
Add documentation with the type signature and kdoc

### DIFF
--- a/semanticdb-kotlinc/build.gradle.kts
+++ b/semanticdb-kotlinc/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
     testImplementation(kotlin("reflect"))
     testImplementation(kotlin("script-runtime", "1.5.0"))
 
-    snapshotsImplementation("com.sourcegraph", "lsif-java_2.13", "0.5.6")
+    snapshotsImplementation("com.sourcegraph", "lsif-java_2.13", "0.6.12")
 }
 
 tasks.withType<KotlinCompile> {

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Class.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Class.kt
@@ -2,11 +2,11 @@ package snapshots
 //      ^^^^^^^^^ reference snapshots/
 
 class Class constructor(private var banana: Int, apple: String) :
-//    ^^^^^ definition snapshots/Class# class Class : kotlin.Throwable
-//          ^^^^^^^^^^^ definition snapshots/Class#`<init>`(). constructor Class(banana: kotlin.Int, apple: kotlin.String)
-//                                  ^^^^^^ definition snapshots/Class#banana. var banana: kotlin.Int
-//                                  ^^^^^^ definition snapshots/Class#getBanana(). var banana: kotlin.Int
-//                                  ^^^^^^ definition snapshots/Class#setBanana(). var banana: kotlin.Int
+//    ^^^^^ definition snapshots/Class# public final class Class : kotlin.Throwable
+//          ^^^^^^^^^^^ definition snapshots/Class#`<init>`(). public constructor Class(banana: kotlin.Int, apple: kotlin.String)
+//                                  ^^^^^^ definition snapshots/Class#banana. private final var banana: kotlin.Int
+//                                  ^^^^^^ definition snapshots/Class#getBanana(). private final var banana: kotlin.Int
+//                                  ^^^^^^ definition snapshots/Class#setBanana(). private final var banana: kotlin.Int
 //                                  ^^^^^^ definition snapshots/Class#`<init>`().(banana) value-parameter banana: kotlin.Int
 //                                          ^^^ reference kotlin/Int#
 //                                               ^^^^^ definition snapshots/Class#`<init>`().(apple) value-parameter apple: kotlin.String
@@ -23,25 +23,25 @@ class Class constructor(private var banana: Int, apple: String) :
   }
 
   val asdf =
-//    ^^^^ definition snapshots/Class#asdf. val asdf: kotlin.Any
-//    ^^^^ definition snapshots/Class#getAsdf(). val asdf: kotlin.Any
+//    ^^^^ definition snapshots/Class#asdf. public final val asdf: kotlin.Any
+//    ^^^^ definition snapshots/Class#getAsdf(). public final val asdf: kotlin.Any
       object {
         fun doStuff() = Unit
-//          ^^^^^^^ definition local0 fun doStuff(): kotlin.Unit
+//          ^^^^^^^ definition local0 public final fun doStuff()
 //                      ^^^^ reference kotlin/Unit#
       }
 
   constructor() : this(1, "")
-//^^^^^^^^^^^ definition snapshots/Class#`<init>`(+1). constructor Class()
+//^^^^^^^^^^^ definition snapshots/Class#`<init>`(+1). public constructor Class()
 
   constructor(banana: Int) : this(banana, "")
-//^^^^^^^^^^^ definition snapshots/Class#`<init>`(+2). constructor Class(banana: kotlin.Int)
+//^^^^^^^^^^^ definition snapshots/Class#`<init>`(+2). public constructor Class(banana: kotlin.Int)
 //            ^^^^^^ definition snapshots/Class#`<init>`(+2).(banana) value-parameter banana: kotlin.Int
 //                    ^^^ reference kotlin/Int#
 //                                ^^^^^^ reference snapshots/Class#`<init>`(+2).(banana)
 
   fun run() {
-//    ^^^ definition snapshots/Class#run(). fun run(): kotlin.Unit
+//    ^^^ definition snapshots/Class#run(). public final fun run()
     println(Class::class)
 //  ^^^^^^^ reference kotlin/io/ConsoleKt#println(+1).
 //          ^^^^^ reference snapshots/Class#

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Class.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Class.kt
@@ -2,14 +2,14 @@ package snapshots
 //      ^^^^^^^^^ reference snapshots/
 
 class Class constructor(private var banana: Int, apple: String) :
-//    ^^^^^ definition snapshots/Class# Class
-//          ^^^^^^^^^^^ definition snapshots/Class#`<init>`(). Class
-//                                  ^^^^^^ definition snapshots/Class#banana. banana
-//                                  ^^^^^^ definition snapshots/Class#getBanana(). banana
-//                                  ^^^^^^ definition snapshots/Class#setBanana(). banana
-//                                  ^^^^^^ definition snapshots/Class#`<init>`().(banana) banana
+//    ^^^^^ definition snapshots/Class# class Class : kotlin.Throwable
+//          ^^^^^^^^^^^ definition snapshots/Class#`<init>`(). constructor Class(banana: kotlin.Int, apple: kotlin.String)
+//                                  ^^^^^^ definition snapshots/Class#banana. var banana: kotlin.Int
+//                                  ^^^^^^ definition snapshots/Class#getBanana(). var banana: kotlin.Int
+//                                  ^^^^^^ definition snapshots/Class#setBanana(). var banana: kotlin.Int
+//                                  ^^^^^^ definition snapshots/Class#`<init>`().(banana) value-parameter banana: kotlin.Int
 //                                          ^^^ reference kotlin/Int#
-//                                               ^^^^^ definition snapshots/Class#`<init>`().(apple) apple
+//                                               ^^^^^ definition snapshots/Class#`<init>`().(apple) value-parameter apple: kotlin.String
 //                                                      ^^^^^^ reference kotlin/String#
     Throwable(banana.toString() + apple) {
 //  ^^^^^^^^^ reference kotlin/Throwable#`<init>`().
@@ -23,25 +23,25 @@ class Class constructor(private var banana: Int, apple: String) :
   }
 
   val asdf =
-//    ^^^^ definition snapshots/Class#asdf. asdf
-//    ^^^^ definition snapshots/Class#getAsdf(). asdf
+//    ^^^^ definition snapshots/Class#asdf. val asdf: kotlin.Any
+//    ^^^^ definition snapshots/Class#getAsdf(). val asdf: kotlin.Any
       object {
         fun doStuff() = Unit
-//          ^^^^^^^ definition local0 doStuff
+//          ^^^^^^^ definition local0 fun doStuff(): kotlin.Unit
 //                      ^^^^ reference kotlin/Unit#
       }
 
   constructor() : this(1, "")
-//^^^^^^^^^^^ definition snapshots/Class#`<init>`(+1). Class
+//^^^^^^^^^^^ definition snapshots/Class#`<init>`(+1). constructor Class()
 
   constructor(banana: Int) : this(banana, "")
-//^^^^^^^^^^^ definition snapshots/Class#`<init>`(+2). Class
-//            ^^^^^^ definition snapshots/Class#`<init>`(+2).(banana) banana
+//^^^^^^^^^^^ definition snapshots/Class#`<init>`(+2). constructor Class(banana: kotlin.Int)
+//            ^^^^^^ definition snapshots/Class#`<init>`(+2).(banana) value-parameter banana: kotlin.Int
 //                    ^^^ reference kotlin/Int#
 //                                ^^^^^^ reference snapshots/Class#`<init>`(+2).(banana)
 
   fun run() {
-//    ^^^ definition snapshots/Class#run(). run
+//    ^^^ definition snapshots/Class#run(). fun run(): kotlin.Unit
     println(Class::class)
 //  ^^^^^^^ reference kotlin/io/ConsoleKt#println(+1).
 //          ^^^^^ reference snapshots/Class#

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/CompanionOwner.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/CompanionOwner.kt
@@ -2,17 +2,17 @@ package snapshots
 //      ^^^^^^^^^ reference snapshots/
 
 class CompanionOwner {
-//    ^^^^^^^^^^^^^^ definition snapshots/CompanionOwner# CompanionOwner
-//    ^^^^^^^^^^^^^^ definition snapshots/CompanionOwner#`<init>`(). CompanionOwner
+//    ^^^^^^^^^^^^^^ definition snapshots/CompanionOwner# class CompanionOwner
+//    ^^^^^^^^^^^^^^ definition snapshots/CompanionOwner#`<init>`(). constructor CompanionOwner()
   companion object {
-//          ^^^^^^^^^ definition snapshots/CompanionOwner#Companion# Companion
+//          ^^^^^^^^^ definition snapshots/CompanionOwner#Companion# companion object
     fun create(): CompanionOwner = CompanionOwner()
-//      ^^^^^^ definition snapshots/CompanionOwner#Companion#create(). create
+//      ^^^^^^ definition snapshots/CompanionOwner#Companion#create(). fun create(): snapshots.CompanionOwner
 //                ^^^^^^^^^^^^^^ reference snapshots/CompanionOwner#
 //                                 ^^^^^^^^^^^^^^ reference snapshots/CompanionOwner#`<init>`().
   }
   fun create(): Int = CompanionOwner.create().hashCode()
-//    ^^^^^^ definition snapshots/CompanionOwner#create(). create
+//    ^^^^^^ definition snapshots/CompanionOwner#create(). fun create(): kotlin.Int
 //              ^^^ reference kotlin/Int#
 //                    ^^^^^^^^^^^^^^ reference snapshots/CompanionOwner#Companion#
 //                                   ^^^^^^ reference snapshots/CompanionOwner#Companion#create().

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/CompanionOwner.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/CompanionOwner.kt
@@ -2,17 +2,17 @@ package snapshots
 //      ^^^^^^^^^ reference snapshots/
 
 class CompanionOwner {
-//    ^^^^^^^^^^^^^^ definition snapshots/CompanionOwner# class CompanionOwner
-//    ^^^^^^^^^^^^^^ definition snapshots/CompanionOwner#`<init>`(). constructor CompanionOwner()
+//    ^^^^^^^^^^^^^^ definition snapshots/CompanionOwner# public final class CompanionOwner
+//    ^^^^^^^^^^^^^^ definition snapshots/CompanionOwner#`<init>`(). public constructor CompanionOwner()
   companion object {
-//          ^^^^^^^^^ definition snapshots/CompanionOwner#Companion# companion object
+//          ^^^^^^^^^ definition snapshots/CompanionOwner#Companion# public companion object
     fun create(): CompanionOwner = CompanionOwner()
-//      ^^^^^^ definition snapshots/CompanionOwner#Companion#create(). fun create(): snapshots.CompanionOwner
+//      ^^^^^^ definition snapshots/CompanionOwner#Companion#create(). public final fun create(): snapshots.CompanionOwner
 //                ^^^^^^^^^^^^^^ reference snapshots/CompanionOwner#
 //                                 ^^^^^^^^^^^^^^ reference snapshots/CompanionOwner#`<init>`().
   }
   fun create(): Int = CompanionOwner.create().hashCode()
-//    ^^^^^^ definition snapshots/CompanionOwner#create(). fun create(): kotlin.Int
+//    ^^^^^^ definition snapshots/CompanionOwner#create(). public final fun create(): kotlin.Int
 //              ^^^ reference kotlin/Int#
 //                    ^^^^^^^^^^^^^^ reference snapshots/CompanionOwner#Companion#
 //                                   ^^^^^^ reference snapshots/CompanionOwner#Companion#create().

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Docstrings.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Docstrings.kt
@@ -7,16 +7,16 @@ import java.io.Serializable
 //             ^^^^^^^^^^^^ reference java/io/Serializable#
 
 abstract class DocstringSuperclass
-//             ^^^^^^^^^^^^^^^^^^^ definition snapshots/DocstringSuperclass# class DocstringSuperclass
-//             ^^^^^^^^^^^^^^^^^^^ definition snapshots/DocstringSuperclass#`<init>`(). constructor DocstringSuperclass()
+//             ^^^^^^^^^^^^^^^^^^^ definition snapshots/DocstringSuperclass# public abstract class DocstringSuperclass
+//             ^^^^^^^^^^^^^^^^^^^ definition snapshots/DocstringSuperclass#`<init>`(). public constructor DocstringSuperclass()
 /** Example class docstring. */
 class Docstrings :  DocstringSuperclass(), Serializable {
-//    ^^^^^^^^^^ definition snapshots/Docstrings# class Docstrings : snapshots.DocstringSuperclass, java.io.Serializable
-//    ^^^^^^^^^^ definition snapshots/Docstrings#`<init>`(). constructor Docstrings()
+//    ^^^^^^^^^^ definition snapshots/Docstrings# public final class Docstrings : snapshots.DocstringSuperclass, java.io.Serializable
+//    ^^^^^^^^^^ definition snapshots/Docstrings#`<init>`(). public constructor Docstrings()
 //                  ^^^^^^^^^^^^^^^^^^^ reference snapshots/DocstringSuperclass#`<init>`().
 //                                         ^^^^^^^^^^^^ reference java/io/Serializable#
 }
 
 /** Example method docstring. */
 fun docstrings() { }
-//  ^^^^^^^^^^ definition snapshots/DocstringsKt#docstrings(). fun docstrings(): kotlin.Unit
+//  ^^^^^^^^^^ definition snapshots/DocstringsKt#docstrings(). public fun docstrings()

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Docstrings.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Docstrings.kt
@@ -7,16 +7,16 @@ import java.io.Serializable
 //             ^^^^^^^^^^^^ reference java/io/Serializable#
 
 abstract class DocstringSuperclass
-//             ^^^^^^^^^^^^^^^^^^^ definition snapshots/DocstringSuperclass# DocstringSuperclass
-//             ^^^^^^^^^^^^^^^^^^^ definition snapshots/DocstringSuperclass#`<init>`(). DocstringSuperclass
+//             ^^^^^^^^^^^^^^^^^^^ definition snapshots/DocstringSuperclass# class DocstringSuperclass
+//             ^^^^^^^^^^^^^^^^^^^ definition snapshots/DocstringSuperclass#`<init>`(). constructor DocstringSuperclass()
 /** Example class docstring. */
 class Docstrings :  DocstringSuperclass(), Serializable {
-//    ^^^^^^^^^^ definition snapshots/Docstrings# Docstrings
-//    ^^^^^^^^^^ definition snapshots/Docstrings#`<init>`(). Docstrings
+//    ^^^^^^^^^^ definition snapshots/Docstrings# class Docstrings : snapshots.DocstringSuperclass, java.io.Serializable
+//    ^^^^^^^^^^ definition snapshots/Docstrings#`<init>`(). constructor Docstrings()
 //                  ^^^^^^^^^^^^^^^^^^^ reference snapshots/DocstringSuperclass#`<init>`().
 //                                         ^^^^^^^^^^^^ reference java/io/Serializable#
 }
 
 /** Example method docstring. */
 fun docstrings() { }
-//  ^^^^^^^^^^ definition snapshots/DocstringsKt#docstrings(). docstrings
+//  ^^^^^^^^^^ definition snapshots/DocstringsKt#docstrings(). fun docstrings(): kotlin.Unit

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Docstrings.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Docstrings.kt
@@ -1,0 +1,22 @@
+package snapshots
+//      ^^^^^^^^^ reference snapshots/
+
+import java.io.Serializable
+//     ^^^^ reference java/
+//          ^^ reference java/io/
+//             ^^^^^^^^^^^^ reference java/io/Serializable#
+
+abstract class DocstringSuperclass
+//             ^^^^^^^^^^^^^^^^^^^ definition snapshots/DocstringSuperclass# DocstringSuperclass
+//             ^^^^^^^^^^^^^^^^^^^ definition snapshots/DocstringSuperclass#`<init>`(). DocstringSuperclass
+/** Example class docstring. */
+class Docstrings :  DocstringSuperclass(), Serializable {
+//    ^^^^^^^^^^ definition snapshots/Docstrings# Docstrings
+//    ^^^^^^^^^^ definition snapshots/Docstrings#`<init>`(). Docstrings
+//                  ^^^^^^^^^^^^^^^^^^^ reference snapshots/DocstringSuperclass#`<init>`().
+//                                         ^^^^^^^^^^^^ reference java/io/Serializable#
+}
+
+/** Example method docstring. */
+fun docstrings() { }
+//  ^^^^^^^^^^ definition snapshots/DocstringsKt#docstrings(). docstrings

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Functions.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Functions.kt
@@ -2,7 +2,7 @@ package snapshots
 //      ^^^^^^^^^ reference snapshots/
 
 fun sampleText(x: String = "") {
-//  ^^^^^^^^^^ definition snapshots/FunctionsKt#sampleText(). fun sampleText(x: kotlin.String = ...): kotlin.Unit
+//  ^^^^^^^^^^ definition snapshots/FunctionsKt#sampleText(). public fun sampleText(x: kotlin.String = ...)
 //             ^ definition snapshots/FunctionsKt#sampleText().(x) value-parameter x: kotlin.String = ...
 //                ^^^^^^ reference kotlin/String#
   println(x)

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Functions.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Functions.kt
@@ -2,8 +2,8 @@ package snapshots
 //      ^^^^^^^^^ reference snapshots/
 
 fun sampleText(x: String = "") {
-//  ^^^^^^^^^^ definition snapshots/FunctionsKt#sampleText(). sampleText
-//             ^ definition snapshots/FunctionsKt#sampleText().(x) x
+//  ^^^^^^^^^^ definition snapshots/FunctionsKt#sampleText(). fun sampleText(x: kotlin.String = ...): kotlin.Unit
+//             ^ definition snapshots/FunctionsKt#sampleText().(x) value-parameter x: kotlin.String = ...
 //                ^^^^^^ reference kotlin/String#
   println(x)
 //^^^^^^^ reference kotlin/io/ConsoleKt#println(+1).

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Lambdas.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Lambdas.kt
@@ -2,27 +2,27 @@ package snapshots
 //      ^^^^^^^^^ reference snapshots/
 
 val x = arrayListOf<String>().forEachIndexed { i, s -> println("$i $s") }
-//  ^ definition snapshots/LambdasKt#x. x
-//  ^ definition snapshots/LambdasKt#getX(). x
+//  ^ definition snapshots/LambdasKt#x. val x: kotlin.Unit
+//  ^ definition snapshots/LambdasKt#getX(). val x: kotlin.Unit
 //      ^^^^^^^^^^^ reference kotlin/collections/CollectionsKt#arrayListOf().
 //                  ^^^^^^ reference kotlin/String#
 //                            ^^^^^^^^^^^^^^ reference kotlin/collections/CollectionsKt#forEachIndexed(+9).
-//                                             ^ definition local0 i
-//                                                ^ definition local1 s
+//                                             ^ definition local0 value-parameter i: kotlin.Int
+//                                                ^ definition local1 value-parameter s: kotlin.String
 //                                                     ^^^^^^^ reference kotlin/io/ConsoleKt#println(+1).
 //                                                               ^ reference local0
 //                                                                  ^ reference local1
 
 val y = "fdsa".run { this.toByteArray() }
-//  ^ definition snapshots/LambdasKt#y. y
-//  ^ definition snapshots/LambdasKt#getY(). y
+//  ^ definition snapshots/LambdasKt#y. val y: kotlin.ByteArray
+//  ^ definition snapshots/LambdasKt#getY(). val y: kotlin.ByteArray
 //             ^^^ reference kotlin/StandardKt#run(+1).
-//                   ^^^^ reference 
+//                   ^^^^ reference
 //                        ^^^^^^^^^^^ reference kotlin/text/StringsKt#toByteArray().
 
 val z = y.let { it.size }
-//  ^ definition snapshots/LambdasKt#z. z
-//  ^ definition snapshots/LambdasKt#getZ(). z
+//  ^ definition snapshots/LambdasKt#z. val z: kotlin.Int
+//  ^ definition snapshots/LambdasKt#getZ(). val z: kotlin.Int
 //      ^ reference snapshots/LambdasKt#y.
 //      ^ reference snapshots/LambdasKt#getY().
 //        ^^^ reference kotlin/StandardKt#let().

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Lambdas.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/Lambdas.kt
@@ -2,8 +2,8 @@ package snapshots
 //      ^^^^^^^^^ reference snapshots/
 
 val x = arrayListOf<String>().forEachIndexed { i, s -> println("$i $s") }
-//  ^ definition snapshots/LambdasKt#x. val x: kotlin.Unit
-//  ^ definition snapshots/LambdasKt#getX(). val x: kotlin.Unit
+//  ^ definition snapshots/LambdasKt#x. public val x: kotlin.Unit
+//  ^ definition snapshots/LambdasKt#getX(). public val x: kotlin.Unit
 //      ^^^^^^^^^^^ reference kotlin/collections/CollectionsKt#arrayListOf().
 //                  ^^^^^^ reference kotlin/String#
 //                            ^^^^^^^^^^^^^^ reference kotlin/collections/CollectionsKt#forEachIndexed(+9).
@@ -14,15 +14,15 @@ val x = arrayListOf<String>().forEachIndexed { i, s -> println("$i $s") }
 //                                                                  ^ reference local1
 
 val y = "fdsa".run { this.toByteArray() }
-//  ^ definition snapshots/LambdasKt#y. val y: kotlin.ByteArray
-//  ^ definition snapshots/LambdasKt#getY(). val y: kotlin.ByteArray
+//  ^ definition snapshots/LambdasKt#y. public val y: kotlin.ByteArray
+//  ^ definition snapshots/LambdasKt#getY(). public val y: kotlin.ByteArray
 //             ^^^ reference kotlin/StandardKt#run(+1).
 //                   ^^^^ reference
 //                        ^^^^^^^^^^^ reference kotlin/text/StringsKt#toByteArray().
 
 val z = y.let { it.size }
-//  ^ definition snapshots/LambdasKt#z. val z: kotlin.Int
-//  ^ definition snapshots/LambdasKt#getZ(). val z: kotlin.Int
+//  ^ definition snapshots/LambdasKt#z. public val z: kotlin.Int
+//  ^ definition snapshots/LambdasKt#getZ(). public val z: kotlin.Int
 //      ^ reference snapshots/LambdasKt#y.
 //      ^ reference snapshots/LambdasKt#getY().
 //        ^^^ reference kotlin/StandardKt#let().

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/ObjectKt.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/ObjectKt.kt
@@ -7,9 +7,9 @@ import java.lang.RuntimeException
 //               ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#
 
 object ObjectKt {
-//     ^^^^^^^^ definition snapshots/ObjectKt# object ObjectKt
+//     ^^^^^^^^ definition snapshots/ObjectKt# public object ObjectKt
   fun fail(message: String?): Nothing {
-//    ^^^^ definition snapshots/ObjectKt#fail(). fun fail(message: kotlin.String?): kotlin.Nothing
+//    ^^^^ definition snapshots/ObjectKt#fail(). public final fun fail(message: kotlin.String?): kotlin.Nothing
 //         ^^^^^^^ definition snapshots/ObjectKt#fail().(message) value-parameter message: kotlin.String?
 //                  ^^^^^^ reference kotlin/String#
 //                            ^^^^^^^ reference kotlin/Nothing#

--- a/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/ObjectKt.kt
+++ b/semanticdb-kotlinc/minimized/src/generatedSnapshots/resources/kotlin/snapshots/ObjectKt.kt
@@ -7,10 +7,10 @@ import java.lang.RuntimeException
 //               ^^^^^^^^^^^^^^^^ reference java/lang/RuntimeException#
 
 object ObjectKt {
-//     ^^^^^^^^ definition snapshots/ObjectKt# ObjectKt
+//     ^^^^^^^^ definition snapshots/ObjectKt# object ObjectKt
   fun fail(message: String?): Nothing {
-//    ^^^^ definition snapshots/ObjectKt#fail(). fail
-//         ^^^^^^^ definition snapshots/ObjectKt#fail().(message) message
+//    ^^^^ definition snapshots/ObjectKt#fail(). fun fail(message: kotlin.String?): kotlin.Nothing
+//         ^^^^^^^ definition snapshots/ObjectKt#fail().(message) value-parameter message: kotlin.String?
 //                  ^^^^^^ reference kotlin/String#
 //                            ^^^^^^^ reference kotlin/Nothing#
     throw RuntimeException(message)

--- a/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/Docstrings.kt
+++ b/semanticdb-kotlinc/minimized/src/main/kotlin/snapshots/Docstrings.kt
@@ -1,0 +1,11 @@
+package snapshots
+
+import java.io.Serializable
+
+abstract class DocstringSuperclass
+/** Example class docstring. */
+class Docstrings :  DocstringSuperclass(), Serializable {
+}
+
+/** Example method docstring. */
+fun docstrings() { }

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbTextDocumentBuilder.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbTextDocumentBuilder.kt
@@ -111,7 +111,13 @@ class SemanticdbTextDocumentBuilder(
         descriptor: DeclarationDescriptor
     ): Semanticdb.Documentation = Documentation {
         format = Semanticdb.Documentation.Format.MARKDOWN
-        val signature = DescriptorRenderer.COMPACT.render(descriptor)
+        val signature =
+            DescriptorRenderer.COMPACT_WITH_MODIFIERS
+                .withOptions {
+                    withSourceFileForTopLevel = true
+                    unitReturnType = false
+                }
+                .render(descriptor)
         val kdoc =
             when (descriptor) {
                 is DeclarationDescriptorWithSource -> descriptor.findKDocString() ?: ""
@@ -141,6 +147,7 @@ class SemanticdbTextDocumentBuilder(
                 start++
             }
             var end = if (line.endsWith("*/")) line.length - 3 else line.length - 1
+            end = maxOf(start, end)
             while (end > start && Character.isWhitespace(line[end])) {
                 end--
             }

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbTextDocumentBuilder.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbTextDocumentBuilder.kt
@@ -134,7 +134,7 @@ class SemanticdbTextDocumentBuilder(
         val out = StringBuilder().append("\n\n").append("----").append("\n")
         kdoc.lineSequence().forEach { line ->
             var start = 0
-            while (start < line.length && Character.isWhitespace(line[start])) {
+            while (start < line.length && line[start].isWhitespace()) {
                 start++
             }
             if (start < line.length && line[start] == '/') {
@@ -143,13 +143,19 @@ class SemanticdbTextDocumentBuilder(
             while (start < line.length && line[start] == '*') {
                 start++
             }
-            while (start < line.length && Character.isWhitespace(line[start])) {
-                start++
-            }
-            var end = if (line.endsWith("*/")) line.length - 3 else line.length - 1
-            end = maxOf(start, end)
-            while (end > start && Character.isWhitespace(line[end])) {
+            var end = line.length - 1
+            if (end > start && line[end] == '/') {
                 end--
+            }
+            while (end > start && line[end] == '*') {
+                end--
+            }
+            while (end > start && line[end].isWhitespace()) {
+                end--
+            }
+            start = minOf(start, line.length - 1)
+            if (end > start) {
+                end++
             }
             out.append("\n").append(line, start, end)
         }

--- a/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
+++ b/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
@@ -11,26 +11,21 @@ import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import java.io.File
 import java.nio.file.Path
 import kotlin.contracts.ExperimentalContracts
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.io.TempDir
 
 @ExperimentalContracts
 class AnalyzerTest {
-    @Test
-    fun `basic test`(@TempDir path: Path) {
+
+    fun compileSemanticdb(path: Path, @Language("kotlin") code: String): TextDocument {
         val buildPath = File(path.resolve("build").toString()).apply { mkdir() }
-
-        val source =
-            SourceFile.testKt(
-                """
-            package sample
-            class Banana {
-                fun foo() { }
-            }""")
-
+        val source = SourceFile.testKt(code)
         lateinit var document: TextDocument
 
         val result =
@@ -49,6 +44,21 @@ class AnalyzerTest {
                 .compile()
 
         result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+        document shouldNotBe null
+        return document
+    }
+
+    @Test
+    fun `basic test`(@TempDir path: Path) {
+        val document =
+            compileSemanticdb(
+                path,
+                """
+            package sample
+            class Banana {
+                fun foo() { }
+            }""")
+
         val occurrences =
             arrayOf(
                 SymbolOccurrence {
@@ -91,11 +101,21 @@ class AnalyzerTest {
                     symbol = "sample/Banana#"
                     language = KOTLIN
                     displayName = "Banana"
+                    documentation =
+                        Documentation {
+                            format = Semanticdb.Documentation.Format.MARKDOWN
+                            message = "```kt\nclass Banana\n```"
+                        }
                 },
                 SymbolInformation {
                     symbol = "sample/Banana#foo()."
                     language = KOTLIN
                     displayName = "foo"
+                    documentation =
+                        Documentation {
+                            format = Semanticdb.Documentation.Format.MARKDOWN
+                            message = "```kt\nfun foo(): kotlin.Unit\n```"
+                        }
                 })
         assertSoftly(document.symbolsList) { withClue(this) { symbols.forEach(::shouldContain) } }
     }
@@ -535,5 +555,75 @@ class AnalyzerTest {
                 .compile()
 
         result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+    }
+
+    @Test
+    fun documentation(@TempDir path: Path) {
+        val document =
+            compileSemanticdb(
+                path,
+                """
+               package sample
+               import java.io.Serializable
+               abstract class DocstringSuperclass
+
+               /** Example class docstring. */
+               class Docstrings: DocstringSuperclass(), Serializable
+               
+               /** Example method docstring. */
+               inline fun docstrings(msg: String): Int { return msg.length }
+        """.trimIndent())
+        val obtainedSymbols =
+            document
+                .symbolsList
+                .map { "----------\n${it.symbol}\n${it.documentation.message}" }
+                .joinToString("\n")
+        val expectedSymbols =
+            """
+----------
+sample/DocstringSuperclass#
+```kt
+class DocstringSuperclass
+```
+----------
+sample/DocstringSuperclass#`<init>`().
+```kt
+constructor DocstringSuperclass()
+```
+----------
+sample/Docstrings#
+```kt
+class Docstrings : sample.DocstringSuperclass, java.io.Serializable
+```
+
+----
+
+Example class docstring
+----------
+sample/Docstrings#`<init>`().
+```kt
+constructor Docstrings()
+```
+
+----
+
+Example class docstring
+----------
+sample/TestKt#docstrings().
+```kt
+inline fun docstrings(msg: kotlin.String): kotlin.Int
+```
+
+----
+
+Example method docstring
+----------
+sample/TestKt#docstrings().(msg)
+```kt
+value-parameter msg: kotlin.String
+```
+""".trim()
+        println(obtainedSymbols)
+        assertEquals(expectedSymbols, obtainedSymbols)
     }
 }

--- a/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
+++ b/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
@@ -105,7 +105,7 @@ class AnalyzerTest {
                     documentation =
                         Documentation {
                             format = Semanticdb.Documentation.Format.MARKDOWN
-                            message = "```kt\nclass Banana\n```"
+                            message = "```kt\npublic final class Banana\n```"
                         }
                 },
                 SymbolInformation {
@@ -115,7 +115,7 @@ class AnalyzerTest {
                     documentation =
                         Documentation {
                             format = Semanticdb.Documentation.Format.MARKDOWN
-                            message = "```kt\nfun foo(): kotlin.Unit\n```"
+                            message = "```kt\npublic final fun foo()\n```"
                         }
                 })
         assertSoftly(document.symbolsList) { withClue(this) { symbols.forEach(::shouldContain) } }

--- a/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
+++ b/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
@@ -623,7 +623,6 @@ sample/TestKt#docstrings().(msg)
 value-parameter msg: kotlin.String
 ```
 """.trim()
-        println(obtainedSymbols)
         assertEquals(expectedSymbols, obtainedSymbols)
     }
 }


### PR DESCRIPTION
Previously, the semanticdb-kotlinc compiler plugin didn't emit the symbol signature or kdoc strings. This commits adds support for this missing feature by rendering the type signature as markdown alongside the kdoc string.

In the future, we can reconsider emitting `SymbolInformation.signature` so that `lsif-java index-semanticdb` can render the symbol signature. However, this change is enough to unblock Kotlin GA™️ support.

Fixes https://github.com/sourcegraph/lsif-kotlin/pull/21