### PR TITLE
Add Bazel support for running kotlin plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,51 @@ This project must be used together with lsif-java. Visit
 [https://sourcegraph.github.io/lsif-java/] for instructions on how to index
 Kotlin projects with lsif-java. Note that lsif-java indexes Kotlin sources even
 if you have no Java code.
+
+# Build with bazel plugin
+
+Important: Make sure that we only run the plugin in `compile_phase` and **not** in `stubs_phase`. See rule def here:
+
+```starlark
+kt_compiler_plugin(
+    name = "kotlin_semanticdb_plugin",
+    compile_phase = True,
+    id = "semanticdb-kotlinc",
+    options = {
+        "sourceroot": "/private/var/tmp/_bazel_jkvarnefalk/ad23c1b0c3ae269eb3abff3b8750adb6/execroot/scip_kt_tests/",
+        "targetroot": "/Users/jkvarnefalk/dev/sp/android/lsif-kotlin",
+    },
+    stubs_phase = False,
+    target_embedded_compiler = True,
+    deps = [
+        ":kotlin_semanticdbx",
+        "//semanticdb-kotlin:semanticdb-java",
+        "//semanticdb-kotlin/src/main/proto/com.sourcegraph.semanticdb_kotlin:semanticdb_java_proto",
+    ],
+)
+```
+
+At the moment, we haven't implemented any smart sourceroot and targetroot mechanism to work around the sandbox features
+in Bazel. It works by hardcoding the tmp dir, but we want to have a better resolver here like in [scip-java](https://github.com/sourcegraph/scip-java/blob/53db85a92162a56ffcc831af60d63b5afa3601b8/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java#L133)
+
+# Running plugin built with Bazel with kotlinc
+
+To build the plugin with bazel, run:
+
+```bash
+bazel build //semanticdb-kotlinc:kotlin_semanticdb_plugin
+```
+
+That command usually outputs a list of jars, we have put this in a convience file called `pack.sh`.
+This file unpacks all of the jars built by bazel and puts them into a combined jar `combined.jar`.
+The `combined.jar` is the jar we will pass as the plugin to kotlinc command:
+
+```bash
+kotlinc \
+   -Xplugin=combined.jar \
+   -P plugin:semanticdb-kotlinc:sourceroot=/Users/jkvarnefalk/dev/sp/android/lsif-kotlin \
+   -P plugin:semanticdb-kotlinc:targetroot=/Users/jkvarnefalk/dev/sp/android/lsif-kotlin \
+   example/src/main/kotlin/sample/Hello.kt
+```
+
+This command will output a file called `META-INF/semanticdb/example/src/main/kotlin/sample/Hello.kt.semanticdb`

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,116 @@
+workspace(name = "scip_kt_tests")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+##############
+# Bazel stdlib
+##############
+# To update this version, copy-paste instructions from https://github.com/bazelbuild/bazel-skylib/releases
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+    urls = [
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+    ],
+)
+
+##########
+# Protobuf
+##########
+# To update this version, copy-paste instructions from https://github.com/bazelbuild/rules_proto/releases
+http_archive(
+    name = "rules_proto",
+    sha256 = "e017528fd1c91c5a33f15493e3a398181a9e821a804eb7ff5acdd1d2d6c2b18d",
+    strip_prefix = "rules_proto-4.0.0-3.20.0",
+    urls = [
+        "https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0-3.20.0.tar.gz",
+    ],
+)
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
+
+###########
+# KOTLIN #
+##########
+"""
+rules_kotlin_version = "1.6.0"
+
+rules_kotlin_sha = "a57591404423a52bd6b18ebba7979e8cd2243534736c5c94d35c89718ea38f94"
+
+http_archive(
+    name = "io_bazel_rules_kotlin",
+    sha256 = rules_kotlin_sha,
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v%s/rules_kotlin_release.tgz" % rules_kotlin_version],
+)
+
+load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
+
+kotlin_repositories()  # if you want the default. Otherwise see custom kotlinc distribution below
+
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
+
+kt_register_toolchains()
+
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
+"""
+
+
+# Use local check-out of repo rules (or a commit-archive from github via http_archive or git_repository)
+local_repository(
+    name = "io_bazel_rules_kotlin",
+    path = "../rules_kotlin/tmp",
+)
+
+load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories", "versions")
+
+kotlin_repositories()
+
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
+
+kt_register_toolchains()
+##############
+# JVM External
+##############
+# To update this version, copy-paste instructions from https://github.com/bazelbuild/rules_jvm_external/releases
+RULES_JVM_EXTERNAL_TAG = "4.2"
+
+RULES_JVM_EXTERNAL_SHA = "cd1a77b7b02e8e008439ca76fd34f5b07aecb8c752961f9640dea15e9e5ba1ca"
+
+http_archive(
+    name = "rules_jvm_external",
+    sha256 = RULES_JVM_EXTERNAL_SHA,
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
+)
+
+load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
+
+rules_jvm_external_deps()
+
+load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
+
+rules_jvm_external_setup()
+
+load("@rules_jvm_external//:defs.bzl", "maven_install")
+
+maven_install(
+    artifacts = [
+        "com.google.protobuf:protobuf-java:3.15.6",
+        "com.google.protobuf:protobuf-java-util:3.15.6",
+        "org.projectlombok:lombok:1.18.22",
+        "org.jetbrains.kotlin:kotlin-compiler-embeddable:1.7.0",
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+    ],
+)
+
+local_repository(
+    name = "scip_java",
+    path = "../scip-java",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,7 +37,6 @@ rules_proto_toolchains()
 ###########
 # KOTLIN #
 ##########
-"""
 rules_kotlin_version = "1.6.0"
 
 rules_kotlin_sha = "a57591404423a52bd6b18ebba7979e8cd2243534736c5c94d35c89718ea38f94"
@@ -56,23 +55,7 @@ load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
 
 kt_register_toolchains()
 
-load("@io_bazel_rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
-"""
 
-
-# Use local check-out of repo rules (or a commit-archive from github via http_archive or git_repository)
-local_repository(
-    name = "io_bazel_rules_kotlin",
-    path = "../rules_kotlin/tmp",
-)
-
-load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories", "versions")
-
-kotlin_repositories()
-
-load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
-
-kt_register_toolchains()
 ##############
 # JVM External
 ##############
@@ -108,9 +91,4 @@ maven_install(
     repositories = [
         "https://repo1.maven.org/maven2",
     ],
-)
-
-local_repository(
-    name = "scip_java",
-    path = "../scip-java",
 )

--- a/debug-project/src/main/kotlin/sample/Main.kt
+++ b/debug-project/src/main/kotlin/sample/Main.kt
@@ -3,6 +3,9 @@ package sample
 class Main<T> {
     private val test: String = ""
 
+    /**
+     * Some comment
+     */
     fun method(something: Any): Array<T?>? {
         var i = 1
         val j = 2

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+
+kt_jvm_library(
+    name = "bazel-example",
+    srcs = glob(["src/main/kotlin/sample/*.kt"]),
+    plugins = ["//semanticdb-kotlinc:kotlin_semanticdb_plugin"],
+)

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -1,8 +1,14 @@
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("//semanticdb-kotlinc:generated_sources_collector.bzl", "generated_sources_collector")
 
 
 kt_jvm_library(
     name = "bazel-example",
     srcs = glob(["src/main/kotlin/sample/*.kt"]),
     plugins = ["//semanticdb-kotlinc:kotlin_semanticdb_plugin"],
+)
+
+generated_sources_collector(
+    name = "bazel-example-sources-test",
+    deps = [":bazel-example"]
 )

--- a/example/src/main/kotlin/sample/Main.kt
+++ b/example/src/main/kotlin/sample/Main.kt
@@ -1,0 +1,31 @@
+package sample
+
+class Main<T> {
+    private val test: String = ""
+
+    /**
+     * Some comment
+     */
+    fun method(something: Any): Array<T?>? {
+        var i = 1
+        val j = 2
+        println("$i $j")
+        return null
+    }
+
+    fun method(burger: String) {}
+
+    val helloWorld =
+        object {
+            val hello = "Hello"
+            val world = "World"
+
+            override fun toString() = "$hello $world"
+        }
+}
+
+val bananas = 1
+
+fun test() = Unit
+
+typealias Stringer = String

--- a/semanticdb-kotlin/BUILD.bazel
+++ b/semanticdb-kotlin/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+java_proto_library(
+    name = "semanticdb_java_proto",
+    deps = [":semanticdb_proto"],
+)
+
+proto_library(
+    name = "semanticdb_proto",
+    srcs = glob(["src/main/protobuf/*.proto"]),
+)
+
+kt_jvm_library(
+    name = "semanticdb-kotlin",
+    srcs = glob(["src/main/java/**/*.kt"]) + glob(["src/main/java/**/*.java"]),
+    deps = [
+        ":semanticdb_java_proto",
+        "@maven//:com_google_protobuf_protobuf_java",
+    ],
+)

--- a/semanticdb-kotlinc/BUILD.bazel
+++ b/semanticdb-kotlinc/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_compiler_plugin")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+kt_compiler_plugin(
+    name = "kotlin_semanticdb_plugin",
+    compile_phase = True,
+    id = "semanticdb-kotlinc",
+    options = {
+        "targetroot": "$(execpath :dummy-for-execpath)",
+        "buildtool": "bazel"
+    },
+    stubs_phase = False,
+    target_embedded_compiler = True,
+    deps = [
+        ":kotlin_semanticdb",
+        ":dummy-for-execpath",
+    ],
+)
+
+java_library(name = "dummy-for-execpath", visibility=["//visibility:private"])
+
+kt_jvm_library(
+    name = "kotlin_semanticdb",
+    srcs = glob(["src/main/kotlin/**/*.kt"]),
+    resources = [
+        "src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor",
+        "src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar",
+    ],
+    deps = [
+        "//semanticdb-kotlin",
+        "//semanticdb-kotlin:semanticdb_java_proto",
+        "@maven//:org_jetbrains_kotlin_kotlin_compiler_embeddable",
+    ],
+)

--- a/semanticdb-kotlinc/BUILD.bazel
+++ b/semanticdb-kotlinc/BUILD.bazel
@@ -10,8 +10,9 @@ kt_compiler_plugin(
     compile_phase = True,
     id = "semanticdb-kotlinc",
     options = {
-        "targetroot": "$(execpath :dummy-for-execpath)",
-        "buildtool": "bazel"
+        "sourceroot": "/private/var/tmp/_bazel_jkvarnefalk/e42f945a330c6dc7b10d832d5e8c7e1e/execroot/spotify/",
+        #"sourceroot": "$(PROJECT_ID)",
+        "targetroot": "/Users/jkvarnefalk/dev/sp/client/client"
     },
     stubs_phase = False,
     target_embedded_compiler = True,
@@ -20,6 +21,7 @@ kt_compiler_plugin(
         ":dummy-for-execpath",
     ],
 )
+
 
 java_library(name = "dummy-for-execpath", visibility=["//visibility:private"])
 

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/Analyzer.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/Analyzer.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
 
 @ExperimentalContracts
 class Analyzer(
-    val sourceroot: Path,
+    val sourceroot: Path? = null,
     val targetroot: Path,
     val callback: (Semanticdb.TextDocument) -> Unit
 ) : AnalysisHandlerExtension {
@@ -28,8 +28,9 @@ class Analyzer(
         val resolver = DescriptorResolver(bindingTrace).also { globals.resolver = it }
         for (file in files) {
             val lineMap = LineMap(project, file)
-            val document = SemanticdbVisitor(sourceroot, resolver, file, lineMap, globals).build()
-            semanticdbOutPathForFile(file)?.apply {
+            val sourceRootPath = sourceroot ?: inferBazelSourceRoot(file)
+            val document = SemanticdbVisitor(sourceRootPath, resolver, file, lineMap, globals).build()
+            semanticdbOutPathForFile(file, sourceRootPath)?.apply {
                 Files.write(this, TextDocuments { addDocuments(document) }.toByteArray())
             }
             callback(document)
@@ -38,10 +39,15 @@ class Analyzer(
         return super.analysisCompleted(project, module, bindingTrace, files)
     }
 
-    private fun semanticdbOutPathForFile(file: KtFile): Path? {
+    private fun inferBazelSourceRoot(file: KtFile): Path {
+        val pathElements = file.virtualFilePath.split("/")
+        return Paths.get(pathElements.take(pathElements.indexOf("execroot") + 2).joinToString("/"))
+    }
+
+    private fun semanticdbOutPathForFile(file: KtFile, sourceRootPath: Path): Path? {
         val normalizedPath = Paths.get(file.virtualFilePath).normalize()
-        if (normalizedPath.startsWith(sourceroot)) {
-            val relative = sourceroot.relativize(normalizedPath)
+        if (normalizedPath.startsWith(sourceRootPath)) {
+            val relative = sourceRootPath.relativize(normalizedPath)
             val filename = relative.fileName.toString() + ".semanticdb"
             val semanticdbOutPath =
                 targetroot

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/Analyzer.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/Analyzer.kt
@@ -46,19 +46,20 @@ class Analyzer(
 
     private fun semanticdbOutPathForFile(file: KtFile, sourceRootPath: Path): Path? {
         val normalizedPath = Paths.get(file.virtualFilePath).normalize()
-        if (normalizedPath.startsWith(sourceRootPath)) {
-            val relative = sourceRootPath.relativize(normalizedPath)
-            val filename = relative.fileName.toString() + ".semanticdb"
-            val semanticdbOutPath =
-                targetroot
-                    .resolve("META-INF")
-                    .resolve("semanticdb")
-                    .resolve(relative)
-                    .resolveSibling(filename)
+        val idx = file.virtualFilePath.indexOf("execroot")
 
-            Files.createDirectories(semanticdbOutPath.parent)
-            return semanticdbOutPath
-        }
+
+        val relative = file.virtualFilePath.subSequence(file.virtualFilePath.indexOf("/", idx+11) + 1, file.virtualFilePath.length).toString()
+        val filename = "$relative.semanticdb"
+        val semanticdbOutPath =
+            targetroot
+                .resolve("META-INF")
+                .resolve("semanticdb")
+                .resolve(filename)
+
+        System.out.println("Output path: $semanticdbOutPath")
+        Files.createDirectories(semanticdbOutPath.parent)
+        return semanticdbOutPath
         System.err.println(
             "given file is not under the sourceroot.\n\tSourceroot: $sourceroot\n\tFile path: ${file.virtualFilePath}\n\tNormalized file path: $normalizedPath")
         return null

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerCommandLineProcessor.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerCommandLineProcessor.kt
@@ -14,6 +14,9 @@ val KEY_SOURCES = CompilerConfigurationKey<Path>(VAL_SOURCES)
 const val VAL_TARGET = "targetroot"
 val KEY_TARGET = CompilerConfigurationKey<Path>(VAL_TARGET)
 
+const val VAL_BUILD_TOOL = "buildtool"
+val KEY_BUILD_TOOL = CompilerConfigurationKey<String>(VAL_BUILD_TOOL)
+
 class AnalyzerCommandLineProcessor : CommandLineProcessor {
     override val pluginId: String = "semanticdb-kotlinc"
     override val pluginOptions: Collection<AbstractCliOption> =
@@ -22,12 +25,18 @@ class AnalyzerCommandLineProcessor : CommandLineProcessor {
                 VAL_SOURCES,
                 "<path>",
                 "the absolute path to the root of the Kotlin sources",
-                required = true),
+                required = false),
             CliOption(
                 VAL_TARGET,
                 "<path>",
                 "the absolute path to the directory where to generate SemanticDB files.",
-                required = true))
+                required = false),
+            CliOption(
+                    VAL_BUILD_TOOL,
+                    "<build-tool>",
+                    "the build tool used, for example bazel, sbt, gradle.",
+                    required = false),
+        )
 
     override fun processOption(
         option: AbstractCliOption,
@@ -37,6 +46,7 @@ class AnalyzerCommandLineProcessor : CommandLineProcessor {
         when (option.optionName) {
             VAL_SOURCES -> configuration.put(KEY_SOURCES, Paths.get(value))
             VAL_TARGET -> configuration.put(KEY_TARGET, Paths.get(value))
+            VAL_BUILD_TOOL -> configuration.put(KEY_BUILD_TOOL, value)
         }
     }
 }

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerRegistrar.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/AnalyzerRegistrar.kt
@@ -14,13 +14,17 @@ class AnalyzerRegistrar(private val callback: (Semanticdb.TextDocument) -> Unit 
         project: MockProject,
         configuration: CompilerConfiguration
     ) {
-        AnalysisHandlerExtension.registerExtension(
-            project,
+        val targetRoot = configuration[KEY_TARGET]
+            ?: throw IllegalArgumentException("configuration key $KEY_TARGET missing")
+        val analyzer = if (configuration[KEY_BUILD_TOOL] ?: "" == "bazel") {
+            Analyzer(targetroot = targetRoot.parent, callback = callback)
+        } else {
             Analyzer(
-                sourceroot = configuration[KEY_SOURCES]
-                        ?: throw IllegalArgumentException("configuration key $KEY_SOURCES missing"),
-                targetroot = configuration[KEY_TARGET]
-                        ?: throw IllegalArgumentException("configuration key $KEY_TARGET missing"),
-                callback = callback))
+                    sourceroot = configuration[KEY_SOURCES]
+                            ?: throw IllegalArgumentException("configuration key $KEY_SOURCES missing"),
+                    targetroot = targetRoot,
+                    callback = callback)
+        }
+        AnalysisHandlerExtension.registerExtension(project, analyzer)
     }
 }

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbVisitor.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/SemanticdbVisitor.kt
@@ -68,17 +68,21 @@ class SemanticdbVisitor(
     }
 
     override fun visitClass(klass: KtClass) {
-        val desc = resolver.fromDeclaration(klass).single()
-        cache[desc].with(desc).emitAll(klass, Role.DEFINITION)
-        if (!klass.hasExplicitPrimaryConstructor()) {
+        val decls = resolver.fromDeclaration(klass)
+
+        if (decls.none() || !klass.hasExplicitPrimaryConstructor()) {
             resolver.syntheticConstructor(klass)?.apply {
                 cache[this].with(this).emitAll(klass, Role.DEFINITION)
             }
+        } else {
+            val desc = resolver.fromDeclaration(klass).single()
+            cache[desc].with(desc).emitAll(klass, Role.DEFINITION)
         }
         super.visitClass(klass)
     }
 
     override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {
+        //throw IllegalArgumentException(constructor.getDebugText())
         val desc = resolver.fromDeclaration(constructor).single()
         // if the constructor is not denoted by the 'constructor' keyword, we want to link it to the
         // class ident


### PR DESCRIPTION
- [ ] Add proper documentation where needed?
- [ ] Remove local workspace rules for `rules_kotlin` in `WORKSPACE`
- [ ] Wait and update based on how [PR in rules_kotlin](https://github.com/bazelbuild/rules_kotlin/pull/797) evolve

An attempt at adding Bazel support for the kotlin plugin. After some trial and error, this approach seems to work. I think it makes for kind of a nice interface, you `only` need to add a single line to the plugins field.

The `kt_compiler_plugin` is not very flexible in what arguments we can pass to it. As far as I could tell from playing around, I couldn't take a [similar approach as in scip-java](https://github.com/sourcegraph/scip-java/blob/ce4d9ae60cb908c06f3739b1e8a79dbbf8b48cf7/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java#L62) to figure out sourceroot and targetroot. 

With the current approach, I allow sourceroot to be the sandboxed path from bazel. This seems to be alright since the `index-semanticdb` is able to figure out the relative paths of the files in the postprocessing step. **Is this assumption valid?**

For figuring out `targetroot` I wanted to put the output files in the correct `bazel-out/<build-configuration>/` folder. The only way I could figure out how to do that was to [allow make variable subsitution ](https://github.com/bazelbuild/rules_kotlin/pull/797)in the `kt_compiler_plugin` `options` field and create a dummy rule like this:

```
kt_compiler_plugin(
    name = "kotlin_semanticdb_plugin",
    compile_phase = True,
    id = "semanticdb-kotlinc",
    options = {
        "targetroot": "$(execpath :dummy-for-execpath)",
        "buildtool": "bazel"
    },
    stubs_phase = False,
    target_embedded_compiler = True,
    deps = [
        ":kotlin_semanticdb",
        ":dummy-for-execpath",
        "//semanticdb-kotlin/src/main/proto/com.sourcegraph.semanticdb_kotlin:semanticdb_java_proto",
    ],
)

java_library(name = "dummy-for-execpath", visibility=["//visibility:private"])
```

Happy to hear if someone has a better approach on this? The other alternative is hardcoding the paths, but that doesn't seem that flexible. Another downside of this is that we are relying on getting the pr to `rules_kotlin` merged and then bazel builds will only work on later versions.


### Test plan

Not sure how to properly set up automated testing for this one. I created a build files and examples under the `example/` project.

To test the project with the make variable subsitution, follow this:

```
# (In the parent folder of the lsif-kotlin project)
git clone git@github.com:bazelbuild/rules_kotlin.git
cd rules_kotlin
bazelisk build //:rules_kotlin_release
mkdir tmp
tar -xvf ../bazel-bin/rules_kotlin_release.tgz
``` 

If that is a hustle, you can try it out with hardcoding the paths like this in the compiler plugin rule:

```
kt_compiler_plugin(
    ...
    options = {
        "targetroot": "<path>",
        "sourcepath": "<path>",
    },
   ...
)
```

And then build the example project with

```
bazelisk build //example:bazel-example
```

