### PR TITLE
catch exceptions instead of letting them hard fail builds

### DIFF
--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/Analyzer.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/Analyzer.kt
@@ -1,15 +1,23 @@
 package com.sourcegraph.semanticdb_kotlinc
 
+import java.io.PrintWriter
+import java.io.Writer
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.contracts.ExperimentalContracts
 import org.jetbrains.kotlin.analyzer.AnalysisResult
+import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.resolve.BindingTrace
 import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
+import org.jetbrains.kotlin.utils.rethrow
+import java.io.StringWriter
 
 @ExperimentalContracts
 class Analyzer(
@@ -19,24 +27,37 @@ class Analyzer(
 ) : AnalysisHandlerExtension {
     private val globals = GlobalSymbolsCache()
 
+    private val messageCollector =
+        CompilerConfiguration()
+            .get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
+
     override fun analysisCompleted(
         project: Project,
         module: ModuleDescriptor,
         bindingTrace: BindingTrace,
         files: Collection<KtFile>
-    ): AnalysisResult? {
-        val resolver = DescriptorResolver(bindingTrace).also { globals.resolver = it }
-        for (file in files) {
-            val lineMap = LineMap(project, file)
-            val document = SemanticdbVisitor(sourceroot, resolver, file, lineMap, globals).build()
-            semanticdbOutPathForFile(file)?.apply {
-                Files.write(this, TextDocuments { addDocuments(document) }.toByteArray())
+    ): AnalysisResult? =
+        try {
+            val resolver = DescriptorResolver(bindingTrace).also { globals.resolver = it }
+            for (file in files) {
+                try {
+                    val lineMap = LineMap(project, file)
+                    val document =
+                        SemanticdbVisitor(sourceroot, resolver, file, lineMap, globals).build()
+                    semanticdbOutPathForFile(file)?.apply {
+                        Files.write(this, TextDocuments { addDocuments(document) }.toByteArray())
+                    }
+                    callback(document)
+                } catch (e: Exception) {
+                    handleException(e)
+                }
             }
-            callback(document)
-        }
 
-        return super.analysisCompleted(project, module, bindingTrace, files)
-    }
+            super.analysisCompleted(project, module, bindingTrace, files)
+        } catch (e: Exception) {
+            handleException(e)
+            super.analysisCompleted(project, module, bindingTrace, files)
+        }
 
     private fun semanticdbOutPathForFile(file: KtFile): Path? {
         val normalizedPath = Paths.get(file.virtualFilePath).normalize()
@@ -56,5 +77,25 @@ class Analyzer(
         System.err.println(
             "given file is not under the sourceroot.\n\tSourceroot: $sourceroot\n\tFile path: ${file.virtualFilePath}\n\tNormalized file path: $normalizedPath")
         return null
+    }
+
+    private fun handleException(e: Exception) {
+        val writer =
+                PrintWriter(
+                    object : Writer() {
+                        val buf = StringBuffer()
+                        override fun close() =
+                            messageCollector.report(
+                                CompilerMessageSeverity.EXCEPTION, buf.toString())
+                        override fun flush() = Unit
+                        override fun write(data: CharArray, offset: Int, len: Int) {
+                            buf.append(data, offset, len)
+                        }
+                    },
+                    false)
+            e.printStackTrace(writer)
+            writer.println(
+                "Please report a bug to https://github.com/sourcegraph/lsif-kotlin with the stack trace above.")
+            writer.close()
     }
 }

--- a/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/Analyzer.kt
+++ b/semanticdb-kotlinc/src/main/kotlin/com/sourcegraph/semanticdb_kotlinc/Analyzer.kt
@@ -10,6 +10,8 @@ import org.jetbrains.kotlin.analyzer.AnalysisResult
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
+import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
 import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
@@ -29,7 +31,7 @@ class Analyzer(
 
     private val messageCollector =
         CompilerConfiguration()
-            .get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
+            .get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, PrintingMessageCollector(System.err, MessageRenderer.PLAIN_FULL_PATHS, false))
 
     override fun analysisCompleted(
         project: Project,
@@ -93,6 +95,7 @@ class Analyzer(
                         }
                     },
                     false)
+            writer.println("Exception in semanticdb-kotlin compiler plugin:")
             e.printStackTrace(writer)
             writer.println(
                 "Please report a bug to https://github.com/sourcegraph/lsif-kotlin with the stack trace above.")

--- a/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
+++ b/semanticdb-kotlinc/src/test/kotlin/com/sourcegraph/semanticdb_kotlinc/test/AnalyzerTest.kt
@@ -122,6 +122,27 @@ class AnalyzerTest {
     }
 
     @Test
+    fun `exception test`(@TempDir path: Path) {
+        val buildPath = File(path.resolve("build").toString()).apply { mkdir() }
+        val result =
+            KotlinCompilation()
+                .apply {
+                    sources = listOf(SourceFile.testKt(""))
+                    compilerPlugins = listOf(AnalyzerRegistrar { throw Exception("sample text") })
+                    verbose = false
+                    pluginOptions =
+                        listOf(
+                            PluginOption("semanticdb-kotlinc", "sourceroot", path.toString()),
+                            PluginOption("semanticdb-kotlinc", "targetroot", buildPath.toString()))
+                    commandLineProcessors = listOf(AnalyzerCommandLineProcessor())
+                    workingDir = path.toFile()
+                }
+                .compile()
+
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+    }
+
+    @Test
     // shamelessly stolen code snippet from https://learnxinyminutes.com/docs/kotlin/
     fun `learn x in y test`(@TempDir path: Path) {
         val buildPath = File(path.resolve("build").toString()).apply { mkdir() }


### PR DESCRIPTION
~~Having issues with getting the exceptions logged (in any way, even directly with stderr), have asked in official slack about it~~ Have implemented a workaround that also involves a change in scip-java, PR here: https://github.com/sourcegraph/scip-java/pull/551

### Test plan

Added unit test and ran E2E via sbt-invoked `scip-java`
