### PR TITLE
Use official Kotlin/Protobuf generator

### DIFF
--- a/semanticdb-kotlin/build.gradle.kts
+++ b/semanticdb-kotlin/build.gradle.kts
@@ -3,7 +3,6 @@ import com.google.protobuf.gradle.*
 plugins {
     kotlin("jvm")
     id("com.google.protobuf") version "0.8.17"
-    id("com.github.marcoferrer.kroto-plus") version "0.6.1"
 }
 
 repositories {
@@ -23,7 +22,7 @@ buildscript {
 dependencies {
     implementation(kotlin("stdlib"))
     implementation("com.google.protobuf:protobuf-java:3.17.3")
-    compileOnly("com.sourcegraph", "semanticdb-javac", "0.6.12")
+    compileOnly("com.sourcegraph", "semanticdb-javac", "0.8.23")
 }
 
 
@@ -45,41 +44,16 @@ afterEvaluate {
     }
 }
 
-krotoPlus {
-    config {
-        create("main") {
-            builder.protoBuilders {
-                useDslMarkers = true
-                unwrapBuilders = true
-            }
-        }
-    }
-}
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.15.7"
+        artifact = "com.google.protobuf:protoc:3.17.3"
     }
 
     generatedFilesBaseDir = kotlin.sourceSets.main.get().kotlin.srcDirs.first().path.split(":")[0].removeSuffix("main/kotlin")
 
     plugins {
-        id("kroto") {
-            artifact = "com.github.marcoferrer.krotoplus:protoc-gen-kroto-plus:0.6.1"
-        }
+        kotlin { }
     }
 
-    generateProtoTasks {
-        val krotoConfig = file("${projectDir}/krotoconfig.json")
-        all().forEach { task ->
-            task.inputs.files(krotoConfig)
-
-            task.plugins {
-                id("kroto") {
-                    outputSubDir = "java"
-                    option("ConfigPath=${krotoConfig}")
-                }
-            }
-        }
-    }
 }

--- a/semanticdb-kotlin/src/main/java/com/sourcegraph/semanticdb_kotlinc/Semanticdb.java
+++ b/semanticdb-kotlin/src/main/java/com/sourcegraph/semanticdb_kotlinc/Semanticdb.java
@@ -578,7 +578,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.TextDocuments)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.TextDocumentsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -1757,7 +1756,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.TextDocument)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.TextDocumentOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -3243,7 +3241,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.Range)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.RangeOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -4166,7 +4163,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.Signature)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.SignatureOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -5447,7 +5443,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.ClassSignature)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.ClassSignatureOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -6647,7 +6642,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.MethodSignature)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.MethodSignatureOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -7826,7 +7820,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.TypeSignature)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.TypeSignatureOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -8714,7 +8707,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.ValueSignature)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.ValueSignatureOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -10161,7 +10153,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.SymbolInformation)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.SymbolInformationOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -11787,7 +11778,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.Access)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.AccessOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -12837,7 +12827,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.PrivateAccess)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.PrivateAccessOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -13323,7 +13312,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.PrivateWithinAccess)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.PrivateWithinAccessOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -13825,7 +13813,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.ProtectedAccess)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.ProtectedAccessOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -14244,7 +14231,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.PublicAccess)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.PublicAccessOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -14912,7 +14898,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.Documentation)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.DocumentationOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -15775,7 +15760,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.SymbolOccurrence)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.SymbolOccurrenceOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -16651,7 +16635,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.Scope)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.ScopeOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -17760,7 +17743,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.Type)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.TypeOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -18816,7 +18798,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.TypeRef)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.TypeRefOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -19693,7 +19674,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.IntersectionType)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.IntersectionTypeOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -20536,7 +20516,6 @@ public final class Semanticdb {
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        com.sourcegraph.semanticdb_kotlinc.SemanticdbDslBuilder,
         // @@protoc_insertion_point(builder_implements:com.sourcegraph.semanticdb_kotlinc.ExistentialType)
         com.sourcegraph.semanticdb_kotlinc.Semanticdb.ExistentialTypeOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor


### PR DESCRIPTION
Previously, we used an unmaintained Kotlin protobuf generator, which didn't support Apple M1 chips. This commit replaces this dependency with the official Protobuf generator, which works on Apple M1.

### Test plan

Green CI.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
