### PR TITLE
configure debug-project to use jar from :semanticdb-kotlinc:shadowJar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.palantir.gradle.gitversion.VersionDetails
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import groovy.lang.Closure
+import org.gradle.jvm.toolchain.internal.CurrentJvmToolchainSpec
 
 plugins {
     kotlin("jvm") version "1.5.30"
@@ -69,7 +70,7 @@ allprojects {
 
         kotlin {
             jvmToolchain {
-                languageVersion.set(JavaLanguageVersion.of(8))
+                (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(8))
             }
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ allprojects {
 
         kotlin {
             jvmToolchain {
-                (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(8))
+                languageVersion.set(JavaLanguageVersion.of(8))
             }
         }
 

--- a/debug-project/build.gradle.kts
+++ b/debug-project/build.gradle.kts
@@ -1,7 +1,4 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import java.nio.file.Files
-import java.nio.file.Paths
-import kotlin.collections.mapOf
 
 plugins {
     kotlin("jvm")
@@ -20,8 +17,24 @@ val semanticdbJar: Configuration by configurations.creating {
 
 dependencies {
     implementation(kotlin("stdlib"))
-    semanticdbJar(project(mapOf(
-        "path" to ":" + projects.semanticdbKotlinc.name,
-        "configuration" to "semanticdbJar"
-    )))
+    semanticdbJar(project(
+        path = ":${projects.semanticdbKotlinc.name}",
+        configuration = "semanticdbJar"
+    ))
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions.jvmTarget = "1.8"
+    dependsOn(":${projects.semanticdbKotlinc.name}:shadowJar")
+    val targetroot = File(project.buildDir, "semanticdb-targetroot")
+    kotlinOptions {
+        jvmTarget = "11"
+        freeCompilerArgs = freeCompilerArgs + listOf(
+            "-Xplugin=${semanticdbJar.first()}",
+            "-P",
+            "plugin:semanticdb-kotlinc:sourceroot=${projectDir.path}",
+            "-P",
+            "plugin:semanticdb-kotlinc:targetroot=${targetroot}"
+        )
+    }
 }

--- a/semanticdb-kotlinc/build.gradle.kts
+++ b/semanticdb-kotlinc/build.gradle.kts
@@ -1,6 +1,5 @@
 import java.net.URI
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.publish.maven.MavenPublication
 
@@ -50,30 +49,23 @@ dependencies {
 }
 
 tasks.withType<KotlinCompile> {
-    dependsOn(projects.semanticdbKotlin.dependencyProject.tasks.build.get().path)
+    dependsOn(":${projects.semanticdbKotlin.name}:build")
     kotlinOptions {
         freeCompilerArgs = freeCompilerArgs + listOf("-Xinline-classes")
     }
 }
 
 val semanticdbJar: Configuration by configurations.creating {
-    afterEvaluate {
-        isCanBeConsumed = true
-        isCanBeResolved = false
-        outgoing.artifact(tasks.shadowJar.get().outputs.files.first())
-    }
+    isCanBeConsumed = true
+    isCanBeResolved = false
 }
 
 artifacts {
-    afterEvaluate {
-        add("semanticdbJar", tasks.shadowJar.get().outputs.files.first()) {
-            builtBy(tasks.shadowJar)
-        }
-    }
+    add(semanticdbJar.name, tasks.shadowJar)
 }
 
 tasks.jar {
-    archiveClassifier.set("-slim")
+    archiveClassifier.set("slim")
     manifest {
         attributes["Specification-Title"] = project.name
         attributes["Specification-Version"] = project.version


### PR DESCRIPTION
Fixing debug-project configuration to more consistently depend on the semanticdb-kotlinc jar having been created

### Test plan

N/A updating debug (sub)project
